### PR TITLE
Replace deprecated method of FastAPI

### DIFF
--- a/llama_agentic_system/server.py
+++ b/llama_agentic_system/server.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import signal
+from contextlib import asynccontextmanager
 
 import fire
 
@@ -41,11 +42,8 @@ def handle_sigint(*args, **kwargs):
     loop.stop()
 
 
-app = FastAPI()
-
-
-@app.on_event("startup")
-async def startup():
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
     global AgenticSystemApiInstance
 
     config = get_config()
@@ -76,6 +74,11 @@ async def startup():
         shield_cfg = safety_config.prompt_guard_shield
         if shield_cfg is not None:
             _ = PromptGuardShield.instance(shield_cfg.model_dir)
+
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 @app.post(


### PR DESCRIPTION
The way a config updater was implemented is deprecated. I replaced the `on_event` with `lifespan`, the latest method. Please take a look at this [reference](https://fastapi.tiangolo.com/advanced/events/).